### PR TITLE
Automate event status

### DIFF
--- a/content/event/festival-0/index.fr.md
+++ b/content/event/festival-0/index.fr.md
@@ -7,7 +7,6 @@ location: Ground Control, Paris
 #meetup_link:
 #kommunity_link:
 image: paris_p2p_festival_0.png
-event_status: future
 special_event: true
 aliases:
 - /festival

--- a/content/event/festival-0/index.md
+++ b/content/event/festival-0/index.md
@@ -7,7 +7,6 @@ location: Ground Control, Paris
 #meetup_link:
 #kommunity_link:
 image: paris_p2p_festival_0.png
-event_status: future
 special_event: true
 aliases:
 ---

--- a/content/event/monthly-0/index.fr.md
+++ b/content/event/monthly-0/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2019-08-07
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/fr-FR/Paris-P2P/events/263089573/
 image: paris_p2p_event_0.png
-event_status: past
 ---
 
 ### <i class="far fa-presentation"></i>Présentations

--- a/content/event/monthly-0/index.md
+++ b/content/event/monthly-0/index.md
@@ -5,7 +5,6 @@ event_date: 2019-08-07
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/fr-FR/Paris-P2P/events/263089573/
 image: paris_p2p_event_0.png
-event_status: past
 ---
 
 ### <i class="far fa-presentation"></i>Talks

--- a/content/event/monthly-1/index.fr.md
+++ b/content/event/monthly-1/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2019-09-04
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/fr-FR/Paris-P2P/events/263171540/
 image: paris_p2p_event_monthly.png
-event_status: past
 ---
 
 ### <i class="far fa-presentation"></i>Présentations

--- a/content/event/monthly-1/index.md
+++ b/content/event/monthly-1/index.md
@@ -5,7 +5,6 @@ event_date: 2019-09-04
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/fr-FR/Paris-P2P/events/263171540/
 image: paris_p2p_event_monthly.png
-event_status: past
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-2/index.fr.md
+++ b/content/event/monthly-2/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2019-10-02
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/fr-FR/Paris-P2P/events/263171540/
 image: paris_p2p_event_monthly.png
-event_status: past
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-2/index.md
+++ b/content/event/monthly-2/index.md
@@ -5,7 +5,6 @@ event_date: 2019-10-02
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/fr-FR/Paris-P2P/events/263191369/
 image: paris_p2p_event_monthly.png
-event_status: past
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-3/index.fr.md
+++ b/content/event/monthly-3/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2019-11-06
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/263191379/
 image: paris_p2p_event_monthly.png
-event_status: past # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-3/index.md
+++ b/content/event/monthly-3/index.md
@@ -5,7 +5,6 @@ event_date: 2019-11-06
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/263191379/
 image: paris_p2p_event_monthly.png
-event_status: past # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-4/index.fr.md
+++ b/content/event/monthly-4/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2019-12-04
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/Paris-P2P/events/264367847/
 image: paris_p2p_event_monthly.png
-event_status: current # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-4/index.md
+++ b/content/event/monthly-4/index.md
@@ -5,7 +5,6 @@ event_date: 2019-12-04
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/Paris-P2P/events/264367847/
 image: paris_p2p_event_monthly.png
-event_status: current # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-5/index.fr.md
+++ b/content/event/monthly-5/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2020-01-08
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590715/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-5/index.md
+++ b/content/event/monthly-5/index.md
@@ -5,7 +5,6 @@ event_date: 2020-01-08
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590715/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-6/index.fr.md
+++ b/content/event/monthly-6/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2020-02-05
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590816/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-6/index.md
+++ b/content/event/monthly-6/index.md
@@ -5,7 +5,6 @@ event_date: 2020-02-05
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590816/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-7/index.fr.md
+++ b/content/event/monthly-7/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2020-03-04
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590827/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-7/index.md
+++ b/content/event/monthly-7/index.md
@@ -5,7 +5,6 @@ event_date: 2020-03-04
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590827/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-8/index.fr.md
+++ b/content/event/monthly-8/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2020-04-01
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590849/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-8/index.md
+++ b/content/event/monthly-8/index.md
@@ -5,7 +5,6 @@ event_date: 2020-04-01
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590849/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/content/event/monthly-9/index.fr.md
+++ b/content/event/monthly-9/index.fr.md
@@ -5,7 +5,6 @@ event_date: 2020-05-06
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590850/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Présentations

--- a/content/event/monthly-9/index.md
+++ b/content/event/monthly-9/index.md
@@ -5,7 +5,6 @@ event_date: 2020-05-06
 location: Ground Control, Paris
 meetup_link: https://www.meetup.com/France-P2P/events/265590850/
 image: paris_p2p_event_monthly.png
-event_status: future # past, current, future
 ---
 
 ### <i class="far fa-presentation"></i> Talks

--- a/themes/p2pparis/layouts/_default/baseof.html
+++ b/themes/p2pparis/layouts/_default/baseof.html
@@ -1,0 +1,36 @@
+{{ $events := sort (where .Site.RegularPages "Section" "event") "Params.event_date" }}
+
+<!-- START: get event status -->
+{{ $.Scratch.Set "upcoming_events" slice }}
+{{ $.Scratch.Set "past_events" slice }}
+
+{{ $now := now.Unix }}
+{{ $next_event := "" }}
+{{ range $events }}
+    {{ $status := "" }}
+
+    {{ $event_date := time .Params.event_date }}
+    {{ $today := $event_date.Unix }}
+    
+    {{ if (ge $today $now) }}
+        <!-- if next event is empty, then this is the first current/upcoming event -->
+        {{ if not $next_event }}
+            {{ $next_event = . }}
+            {{ $status = "next-on" }}
+        {{ else }}
+            {{ $status = "future" }}
+        {{ end }}
+        {{ $.Scratch.Add "upcoming_events" . }}
+    {{ else }}
+        {{ $status = "past" }}
+        {{ $.Scratch.Add "past_events" . }}
+    {{ end }}
+
+    {{ $.Scratch.SetInMap "event_status" .UniqueID $status }}
+{{ end }}
+
+<!-- END: get event status -->
+
+{{ partial "header" . }}
+{{ block "main" . }}{{ end }}
+{{ partial "footer" .}}

--- a/themes/p2pparis/layouts/_default/baseof.html
+++ b/themes/p2pparis/layouts/_default/baseof.html
@@ -6,31 +6,35 @@
 
 {{ $now := now.Unix }}
 {{ $next_event := "" }}
+
 {{ range $events }}
-    {{ $status := "" }}
+  {{ $status := "" }}
+  {{ $event_date := time .Params.event_date }}
+  {{ $today := $event_date.Unix }}
 
-    {{ $event_date := time .Params.event_date }}
-    {{ $today := $event_date.Unix }}
-    
-    {{ if (ge $today $now) }}
-        <!-- if next event is empty, then this is the first current/upcoming event -->
-        {{ if not $next_event }}
-            {{ $next_event = . }}
-            {{ $status = "next-on" }}
-        {{ else }}
-            {{ $status = "future" }}
-        {{ end }}
-        {{ $.Scratch.Add "upcoming_events" . }}
+  <!-- if the event date is after today midnight UTC, its in the future -->
+  {{ if (ge $today $now) }}
+
+    {{ $.Scratch.Add "upcoming_events" . }}
+
+    <!-- if next event is empty, then this is the first current/upcoming event -->
+    {{ if not $next_event }}
+      {{ $next_event = . }}
+      {{ $status = "next-on" }}
+
     {{ else }}
-        {{ $status = "past" }}
-        {{ $.Scratch.Add "past_events" . }}
+      {{ $status = "future" }}
     {{ end }}
+  
+  {{ else }}
+    {{ $status = "past" }}
+    {{ $.Scratch.Add "past_events" . }}
+  {{ end }}
 
-    {{ $.Scratch.SetInMap "event_status" .UniqueID $status }}
+  {{ $.Scratch.SetInMap "event_status" .UniqueID $status }}
 {{ end }}
-
 <!-- END: get event status -->
 
 {{ partial "header" . }}
-{{ block "main" . }}{{ end }}
+  {{ block "main" . }}{{ end }} 
 {{ partial "footer" .}}

--- a/themes/p2pparis/layouts/_default/baseof.html
+++ b/themes/p2pparis/layouts/_default/baseof.html
@@ -1,19 +1,17 @@
-{{ $events := sort (where .Site.RegularPages "Section" "event") "Params.event_date" }}
-
 <!-- START: get event status -->
 {{ $.Scratch.Set "upcoming_events" slice }}
 {{ $.Scratch.Set "past_events" slice }}
 
 {{ $now := now.Unix }}
 {{ $next_event := "" }}
+{{ $events := sort (where .Site.RegularPages "Section" "event") "Params.event_date" }}
 
 {{ range $events }}
   {{ $status := "" }}
-  {{ $event_date := time .Params.event_date }}
-  {{ $today := $event_date.Unix }}
+  {{ $event_date := (time .Params.event_date).Unix }}
 
   <!-- if the event date is after today midnight UTC, its in the future -->
-  {{ if (ge $today $now) }}
+  {{ if (ge $event_date $now) }}
 
     {{ $.Scratch.Add "upcoming_events" . }}
 

--- a/themes/p2pparis/layouts/_default/index.html
+++ b/themes/p2pparis/layouts/_default/index.html
@@ -1,4 +1,4 @@
-{{ partial "header" . }}
+{{ define "main" }}
 
 <!-- Masthead -->
 <header class="masthead">
@@ -102,4 +102,5 @@
         {{ partial "links" . }}
     </div><!-- /.container -->
 </section>
-{{ partial "footer" . }}
+
+{{ end }}

--- a/themes/p2pparis/layouts/_default/index.html
+++ b/themes/p2pparis/layouts/_default/index.html
@@ -1,3 +1,31 @@
+{{ $s := newScratch }}
+
+{{ $events := sort (where .Site.RegularPages "Section" "event") "Params.event_date" }}
+
+{{ $now := now.Unix }}
+{{ $next_event := "" }}
+{{ range $events }}
+    {{ $status := "" }}
+
+    {{ $event_date := time .Params.event_date }}
+    {{ $today := $event_date.Unix }}
+    {{ $tomorrow := ($event_date.AddDate 0 0 1).Unix }}
+    
+    {{ if (ge $today $now) }}
+        <!-- if next event is empty, then this is the first current/upcoming event -->
+        {{ if not $next_event }}
+            {{ $next_event = . }}
+            {{ $status = "next-on" }}
+        {{ else }}
+            {{ $status = "future" }}
+        {{ end }}
+    {{ else }}
+        {{ $status = "past" }}
+    {{ end }}
+
+    {{ $s.SetInMap "event_status" .UniqueID $status }}
+{{ end }}
+
 {{ partial "header" . }}
 
 <!-- Masthead -->
@@ -46,10 +74,13 @@
             </div>
         </div>
         <div class="row">
-            {{ range sort (where (where .Site.RegularPages "Section" "event") ".Params.event_status" "!=" "past") "Params.event_date" }}
-            <div class="col-lg-4 col-md-6">
-                {{ partial "block_event" . }}
-            </div><!-- /.col -->
+            {{ range sort $events "Params.event_date" }}
+                {{ $status := index ($s.Get "event_status") .UniqueID }}
+                {{ if or (eq $status "future") (eq $status "next-on") }}
+                <div class="col-lg-4 col-md-6">
+                    {{ partial "block_event" (dict "ctx" . "status" $status) }}
+                </div><!-- /.col -->
+                {{ end }}
             {{ end }}
         </div><!-- /.row -->
         <div class="row justify-content-center">
@@ -61,10 +92,13 @@
             </div>
         </div>
         <div class="row">
-            {{ range sort (where (where .Site.RegularPages "Section" "event") ".Params.event_status" "==" "past") "Params.event_date" }}
-            <div class="col-lg-4 col-md-6">
-                {{ partial "block_event" . }}
-            </div><!-- /.col -->
+            {{ range sort $events "Params.event_date" }}
+                {{ $status := index ($s.Get "event_status") .UniqueID }}
+                {{ if eq $status "past" }}
+                <div class="col-lg-4 col-md-6">
+                    {{ partial "block_event" (dict "ctx" . "status" $status) }}
+                </div><!-- /.col -->
+                {{ end }}
             {{ end }}
         </div><!-- /.row -->
     </div>

--- a/themes/p2pparis/layouts/_default/index.html
+++ b/themes/p2pparis/layouts/_default/index.html
@@ -1,31 +1,3 @@
-{{ $s := newScratch }}
-
-{{ $events := sort (where .Site.RegularPages "Section" "event") "Params.event_date" }}
-
-{{ $now := now.Unix }}
-{{ $next_event := "" }}
-{{ range $events }}
-    {{ $status := "" }}
-
-    {{ $event_date := time .Params.event_date }}
-    {{ $today := $event_date.Unix }}
-    {{ $tomorrow := ($event_date.AddDate 0 0 1).Unix }}
-    
-    {{ if (ge $today $now) }}
-        <!-- if next event is empty, then this is the first current/upcoming event -->
-        {{ if not $next_event }}
-            {{ $next_event = . }}
-            {{ $status = "next-on" }}
-        {{ else }}
-            {{ $status = "future" }}
-        {{ end }}
-    {{ else }}
-        {{ $status = "past" }}
-    {{ end }}
-
-    {{ $s.SetInMap "event_status" .UniqueID $status }}
-{{ end }}
-
 {{ partial "header" . }}
 
 <!-- Masthead -->
@@ -74,13 +46,10 @@
             </div>
         </div>
         <div class="row">
-            {{ range sort $events "Params.event_date" }}
-                {{ $status := index ($s.Get "event_status") .UniqueID }}
-                {{ if or (eq $status "future") (eq $status "next-on") }}
-                <div class="col-lg-4 col-md-6">
-                    {{ partial "block_event" (dict "ctx" . "status" $status) }}
-                </div><!-- /.col -->
-                {{ end }}
+            {{ range ($.Scratch.Get "upcoming_events") }}
+            <div class="col-lg-4 col-md-6">
+                {{ partial "block_event" . }}
+            </div><!-- /.col -->
             {{ end }}
         </div><!-- /.row -->
         <div class="row justify-content-center">
@@ -92,13 +61,10 @@
             </div>
         </div>
         <div class="row">
-            {{ range sort $events "Params.event_date" }}
-                {{ $status := index ($s.Get "event_status") .UniqueID }}
-                {{ if eq $status "past" }}
-                <div class="col-lg-4 col-md-6">
-                    {{ partial "block_event" (dict "ctx" . "status" $status) }}
-                </div><!-- /.col -->
-                {{ end }}
+            {{ range ($.Scratch.Get "past_events") }}
+            <div class="col-lg-4 col-md-6">
+                {{ partial "block_event" . }}
+            </div><!-- /.col -->
             {{ end }}
         </div><!-- /.row -->
     </div>

--- a/themes/p2pparis/layouts/_default/single.html
+++ b/themes/p2pparis/layouts/_default/single.html
@@ -1,3 +1,3 @@
-{{ partial "header" . }}
+{{ define "main" }}
 {{ .Content }}
-{{ partial "footer" .}}
+{{ end }}

--- a/themes/p2pparis/layouts/event/list.html
+++ b/themes/p2pparis/layouts/event/list.html
@@ -1,5 +1,4 @@
-{{ partial "header" . }}
-
+{{ define "main" }}
 <div class="">
     <div class="container h-100">
         <div class="row single">
@@ -11,5 +10,4 @@
         </div><!-- /.row -->
     </div><!-- /.container -->
 </div>
-
-{{ partial "footer" . }}
+{{ end }}

--- a/themes/p2pparis/layouts/event/list.html
+++ b/themes/p2pparis/layouts/event/list.html
@@ -2,7 +2,7 @@
 <div class="">
     <div class="container h-100">
         <div class="row single">
- 			{{ range where .Pages "Section" "event" }}
+ 			{{ range sort .RegularPages "Params.event_date" }}
  			<div class="col-lg-4 col-sm-6">
  				{{ partial "block_event" . }}
  			</div><!-- /.col -->

--- a/themes/p2pparis/layouts/event/single.html
+++ b/themes/p2pparis/layouts/event/single.html
@@ -1,7 +1,7 @@
+{{ define "main" }}
+
 {{ $image := index (.Resources.Match .Params.image) 0 }}
 {{ $image := $image.Resize "1200x" }}
-
-{{ partial "header" . }}
 
 <div class="single">
     <div class="container h-100">
@@ -28,6 +28,4 @@
     </div><!-- /.container -->
 </div>
 
-
-
-{{ partial "footer" . }}
+{{ end }}

--- a/themes/p2pparis/layouts/partials/block_event.html
+++ b/themes/p2pparis/layouts/partials/block_event.html
@@ -1,14 +1,20 @@
-{{ $image := index (.ctx.Resources.Match .ctx.Params.image) 0 }}
+{{ $statuses := $.Scratch.Get "event_status" }}
+{{ $image := index (.Resources.Match .Params.image) 0 }}
 {{ $image := $image.Resize "350x" }}
 
-<a class="block block-event {{.status}}-event" href="{{.ctx.RelPermalink}}">
+{{ $status := ""}}
+{{ if ($statuses) }}
+	{{ $status = index ($statuses) .UniqueID }}
+{{ end }}
+
+<a class="block block-event {{$status}}-event" href="{{.RelPermalink}}">
 	<div class="block-img">
     	<img src="{{ $image.RelPermalink }}">
 	</div><!-- /.block-img -->
 	<div class="block-content">
-		<h4 class="event-title">{{.ctx.Title}}</h4>
-		<p class="event-subtitle">{{.ctx.Params.Subtitle}}</p>
-		<span class="event-info event-date"><i class="far fa-calendar-alt"></i>{{.ctx.Params.Event_date}}</span>
-		<span class="event-info event-location"><i class="far fa-map-marker"></i>{{.ctx.Params.Location}}</span>
+		<h4 class="event-title">{{.Title}}</h4>
+		<p class="event-subtitle">{{.Params.Subtitle}}</p>
+		<span class="event-info event-date"><i class="far fa-calendar-alt"></i>{{.Params.Event_date}}</span>
+		<span class="event-info event-location"><i class="far fa-map-marker"></i>{{.Params.Location}}</span>
 	</div><!-- /.block-content -->
 </a><!-- /.block-event -->

--- a/themes/p2pparis/layouts/partials/block_event.html
+++ b/themes/p2pparis/layouts/partials/block_event.html
@@ -1,14 +1,14 @@
-{{ $image := index (.Resources.Match .Params.image) 0 }}
+{{ $image := index (.ctx.Resources.Match .ctx.Params.image) 0 }}
 {{ $image := $image.Resize "350x" }}
 
-<a class="block block-event {{.Params.event_status}}-event" href="{{.RelPermalink}}">
+<a class="block block-event {{.status}}-event" href="{{.ctx.RelPermalink}}">
 	<div class="block-img">
     	<img src="{{ $image.RelPermalink }}">
 	</div><!-- /.block-img -->
 	<div class="block-content">
-		<h4 class="event-title">{{.Title}}</h4>
-		<p class="event-subtitle">{{.Params.Subtitle}}</p>
-		<span class="event-info event-date"><i class="far fa-calendar-alt"></i>{{.Params.Event_date}}</span>
-		<span class="event-info event-location"><i class="far fa-map-marker"></i>{{.Params.Location}}</span>
+		<h4 class="event-title">{{.ctx.Title}}</h4>
+		<p class="event-subtitle">{{.ctx.Params.Subtitle}}</p>
+		<span class="event-info event-date"><i class="far fa-calendar-alt"></i>{{.ctx.Params.Event_date}}</span>
+		<span class="event-info event-location"><i class="far fa-map-marker"></i>{{.ctx.Params.Location}}</span>
 	</div><!-- /.block-content -->
 </a><!-- /.block-event -->

--- a/themes/p2pparis/layouts/partials/header.html
+++ b/themes/p2pparis/layouts/partials/header.html
@@ -2,39 +2,6 @@
 {{ $.Scratch.Set "description" (.Description | default .Site.Params.default_description) }}
 {{ $.Scratch.Set "featured_image" (.Site.Params.default_featured_image | absURL) }}
 
-{{ $events := sort (where .Site.RegularPages "Section" "event") "Params.event_date" }}
-
-<!-- START: get event status -->
-{{ $.Scratch.Set "upcoming_events" slice }}
-{{ $.Scratch.Set "past_events" slice }}
-
-{{ $now := now.Unix }}
-{{ $next_event := "" }}
-{{ range $events }}
-    {{ $status := "" }}
-
-    {{ $event_date := time .Params.event_date }}
-    {{ $today := $event_date.Unix }}
-    
-    {{ if (ge $today $now) }}
-        <!-- if next event is empty, then this is the first current/upcoming event -->
-        {{ if not $next_event }}
-            {{ $next_event = . }}
-            {{ $status = "next-on" }}
-        {{ else }}
-            {{ $status = "future" }}
-        {{ end }}
-        {{ $.Scratch.Add "upcoming_events" . }}
-    {{ else }}
-        {{ $status = "past" }}
-        {{ $.Scratch.Add "past_events" . }}
-    {{ end }}
-
-    {{ $.Scratch.SetInMap "event_status" .UniqueID $status }}
-{{ end }}
-
-<!-- END: get event status -->
-
 <!DOCTYPE html>
 <html lang="{{ .Lang }}">
 

--- a/themes/p2pparis/layouts/partials/header.html
+++ b/themes/p2pparis/layouts/partials/header.html
@@ -2,6 +2,39 @@
 {{ $.Scratch.Set "description" (.Description | default .Site.Params.default_description) }}
 {{ $.Scratch.Set "featured_image" (.Site.Params.default_featured_image | absURL) }}
 
+{{ $events := sort (where .Site.RegularPages "Section" "event") "Params.event_date" }}
+
+<!-- START: get event status -->
+{{ $.Scratch.Set "upcoming_events" slice }}
+{{ $.Scratch.Set "past_events" slice }}
+
+{{ $now := now.Unix }}
+{{ $next_event := "" }}
+{{ range $events }}
+    {{ $status := "" }}
+
+    {{ $event_date := time .Params.event_date }}
+    {{ $today := $event_date.Unix }}
+    
+    {{ if (ge $today $now) }}
+        <!-- if next event is empty, then this is the first current/upcoming event -->
+        {{ if not $next_event }}
+            {{ $next_event = . }}
+            {{ $status = "next-on" }}
+        {{ else }}
+            {{ $status = "future" }}
+        {{ end }}
+        {{ $.Scratch.Add "upcoming_events" . }}
+    {{ else }}
+        {{ $status = "past" }}
+        {{ $.Scratch.Add "past_events" . }}
+    {{ end }}
+
+    {{ $.Scratch.SetInMap "event_status" .UniqueID $status }}
+{{ end }}
+
+<!-- END: get event status -->
+
 <!DOCTYPE html>
 <html lang="{{ .Lang }}">
 

--- a/themes/p2pparis/static/css/creative.css
+++ b/themes/p2pparis/static/css/creative.css
@@ -10409,7 +10409,7 @@ a.block:hover {
     opacity: 0.9;
 }
 
-.block-event.current-event {
+.block-event.next-on-event {
     opacity: 1;
 }
 


### PR DESCRIPTION
Resolves #60

Statuses:
- past
- next-one (current or first upcoming event)
- future (after "next-one")

Depending on event status, automatically:
- Add them to "Events" or "Past Events"
- Add status to Event block's CSS class

Not entirely sure, but it seems when defining the global variables anywhere other than baseof.html, it can cause inconsistency, and sometimes the global variables are nil. I guess this might be a race condition on the partial rendering. So I have changed it to use Hugo base templates instead (https://gohugo.io/templates/base/).

So be aware to use the following in a layouts page:
```
{{ define "main" }} 
... 
{{ end }}
```

instead of: 
```
{{ partial "header" . }}
...
{{ partial "footer" . }}
```
