### PR TITLE
Add 2022 Festival: P2P Paris #1

### DIFF
--- a/themes/p2pparis/assets/css/creative.css
+++ b/themes/p2pparis/assets/css/creative.css
@@ -10192,7 +10192,7 @@ section h1 notif {
   color: #fff;
 }
 .navbar .navbar-toggler {
- color: rgba(255, 255, 255, 0.7); 
+ color: rgba(255, 255, 255, 0.7);
 }
 .navbar .language-switcher .btn {
   color: rgba(255, 255, 255, 0.7);
@@ -10290,6 +10290,12 @@ body.page-festival {
   background: linear-gradient(0deg, rgba(160,46,168,1) 0%, rgba(217,14,173,1) 100%);
   background-attachment: fixed;
 }
+body.page-festival-1 {
+  background: rgb(160,46,168);
+  background: linear-gradient(0deg, rgba(0, 0, 0,1) 0%, rgba(6, 0, 99,1) 100%);
+  background-attachment: fixed;
+}
+
 
 {{ $bg_festival := (resources.Get "/img/bg_festival.png").Resize "1280x Linear q90 jpg" }}
 
@@ -10304,7 +10310,19 @@ body.page-festival {
   }
 }
 
-.bg-people {
+@media(min-width:768px){
+  body.page-festival-1 {
+    background: -webkit-gradient(linear, left top, left bottom, from( rgba(6, 0, 99, 0.4)), to(rgba(0, 0, 0, 0.8))), url("../img/bg_people.jpg");
+    background: linear-gradient(to bottom, rgba(6, 0, 99, 0.6) 0%, rgba(0, 0, 0, 0.9) 100%), url("../img/bg_people.jpg");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-attachment: fixed;
+    background-size: cover;
+  }
+}
+
+
+.bg-people-pink {
   background: -webkit-gradient(linear, left top, left bottom, from(rgba(217, 14, 173, 0.8) ), to(rgba(160, 46, 168, 0.9) 100%))), url("../img/bg_people.jpg");
   background:linear-gradient(to bottom, rgba(2217, 14, 173, 0.8) 0%, rgba(160, 46, 168, 0.9) 100%), url(../img/bg_people.jpg);
   background-position: center;
@@ -10325,6 +10343,10 @@ body.page-festival {
 .page-festival header.masthead {
   padding: 20px 0;
 }
+.page-festival-1 header.masthead {
+  padding: 20px 0;
+}
+
 
 
 header.masthead h1 {
@@ -10340,6 +10362,9 @@ header.masthead .logo-center {
   display:flex;
 }
 .page-festival header.masthead .logo-center {
+  display:block;
+}
+.page-festival-1 header.masthead .logo-center {
   display:block;
 }
 header.masthead .logo-center img {
@@ -10366,6 +10391,9 @@ header.masthead .logo-center img {
   .page-festival header.masthead .logo-center {
     width:32%;
   }
+  .page-festival-1 header.masthead .logo-center {
+    width:32%;
+  }
   .language-switcher {
     margin-left:30px;
   }
@@ -10373,6 +10401,9 @@ header.masthead .logo-center img {
 
 @media (max-width: 991px) {
   .page-festival header.masthead .logo-center {
+    width:42%;
+  }
+  .page-festival-1 header.masthead .logo-center {
     width:42%;
   }
   header.masthead h1.text-xl {
@@ -10545,11 +10576,11 @@ tag.b {
 }
 tag.p {
   color: #d90ead;
-  background-color: #ffdff8; 
+  background-color: #ffdff8;
 }
 tag.v {
   color: #a02ea8;
-  background-color: #fee4e9; 
+  background-color: #fee4e9;
 }
 
 .block-event .tag {
@@ -10872,7 +10903,7 @@ tag.v {
   background-color:#fc9f12;
   border-color:#fc9f12;
   color:#FFF !important;
-} 
+}
 .btn-meetup i.fa-meetup {
   margin-right:8px;
   font-size:118%;
@@ -10903,7 +10934,7 @@ tag.v {
   padding:15px 38px;
   display:inline;
   font-size: 1.4rem;
-  font-weight: bold; 
+  font-weight: bold;
   color: #FFF;
 }
 .s-day .s-day-title:before{
@@ -11029,7 +11060,7 @@ tag.v {
 .s-item .video-preview {
   float:right;
   margin-left:10px;
-} 
+}
 .s-item a.video-preview {
   display:block;
   position:relative;
@@ -11115,7 +11146,7 @@ tag.v {
 .section-print .s-item.block {
   box-shadow:none;
   border:1.5px dashed transparent;
-} 
+}
 .section-print .s-item .btn.btn-meetup {
   display:none;
 }
@@ -11688,7 +11719,7 @@ tag.v {
   height:70px;
   margin-bottom:20px;
   position:relative;
-} 
+}
 .block-speaker .speaker-picture-hover{
   height:100%;
   width:100%;
@@ -11856,7 +11887,7 @@ a.block-legend-header:focus {
 @media(min-width:992px) and (max-width:1200px) {
  .lang-en .section-info .block.block-link p{
     min-height:48px;
- } 
+ }
 }
 
 @media(max-width:767px) {

--- a/themes/p2pparis/layouts/event/festival-1.html
+++ b/themes/p2pparis/layouts/event/festival-1.html
@@ -1,0 +1,20 @@
+{{ partial "ldjson/event" (dict "ctx" . "id" .Params.id) }}
+
+{{.Scratch.Set "body-class" "page-festival-1"}}
+{{ partial "header" . }}
+
+{{ partial "navbar_festival" . }}
+{{ partial "masthead_festival_1" . }}
+{{ partial "section_numbers" . }}
+{{ partial "section_donate" . }}
+{{ partial "section_schedule" . }}
+<section class="page-section section-about" id="about">
+{{ partial "section_about" . }}
+{{ partial "section_goals" . }}
+</section>
+{{ partial "section_speakers" . }}
+{{ partial "section_info_1" . }}
+{{ partial "section_plan" . }}
+{{ partial "section_links" . }}
+{{ partial "footer" . }}
+

--- a/themes/p2pparis/layouts/event/festival.html
+++ b/themes/p2pparis/layouts/event/festival.html
@@ -8,7 +8,7 @@
 {{ partial "section_numbers" . }}
 {{ partial "section_donate" . }}
 {{ partial "section_schedule" . }}
-<section class="page-section bg-people section-about" id="about">
+<section class="page-section bg-people-pink section-about" id="about">
 {{ partial "section_about" . }}
 {{ partial "section_goals" . }}
 </section>

--- a/themes/p2pparis/layouts/partials/masthead_festival_1.html
+++ b/themes/p2pparis/layouts/partials/masthead_festival_1.html
@@ -1,0 +1,37 @@
+<header class="masthead">
+    <div class="container">
+        <div class="row  align-items-center justify-content-center text-center">
+            <div class="col-lg-10">
+                <div id="logo" class="logo-center">
+                    <img src="/img/paris_p2p_festival.svg">
+                </div>
+                <h1 class="text-uppercase text-white font-weight-bold">{{ i18n "festival_content_intro_text" | markdownify }}</h1>
+            </div><!-- /.col -->
+            <div class="col-lg-10" >
+              <h2 id="it-soon" class="text-uppercase text-white font-weight-bold" style="display: none;">{{ i18n "festival_content_it_soon" }}<br/><br/></h2>
+              <h2 id="it-current" class="text-uppercase text-white font-weight-bold" style="display: none;">{{ i18n "festival_content_it_current" }}<br/><br/></h2>
+              <h2 id="it-finish" class="text-uppercase text-white font-weight-bold" style="display: none;">{{ i18n "festival_content_it_finish" | markdownify }}</h2>
+            </div>
+            <div class="col-lg-10">
+                <div id="clockdiv" style="display: none;">
+                  <div>
+                    <span class="days"></span>
+                    <div class="smalltext">{{ i18n "festival_clock_days" }}</div>
+                  </div>
+                  <div>
+                    <span class="hours"></span>
+                    <div class="smalltext">{{ i18n "festival_clock_hours" }}</div>
+                  </div>
+                  <div>
+                    <span class="minutes"></span>
+                    <div class="smalltext">{{ i18n "festival_clock_minutes" }}</div>
+                  </div>
+                  <div>
+                    <span class="seconds"></span>
+                    <div class="smalltext">{{ i18n "festival_clock_seconds" }}</div>
+                  </div>
+                </div>
+            </div><!-- /.col -->
+        </div><!-- /.row -->
+    </div><!-- /.container -->
+</header>

--- a/themes/p2pparis/layouts/partials/section_info.html
+++ b/themes/p2pparis/layouts/partials/section_info.html
@@ -1,6 +1,6 @@
 {{ $place := index .Params.place 0 }}
 
-<section class="page-section bg-people section-info" id="info">
+<section class="page-section bg-people-pink section-info" id="info">
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-lg-8 text-center">

--- a/themes/p2pparis/layouts/partials/section_info_1.html
+++ b/themes/p2pparis/layouts/partials/section_info_1.html
@@ -1,0 +1,51 @@
+{{ $place := index .Params.place 0 }}
+
+<section class="page-section section-info" id="info">
+    <div class="container">
+        <div class="row justify-content-center">
+            <div class="col-lg-8 text-center">
+                <i class="fal fa-info-circle fa-5x mb-4 text-white"></i>
+                <h2 class="mt-0 text-white">{{ i18n "festival_content_info_title" }}</h2>
+                <hr class="divider light my-4">
+                <br />
+            </div><!-- /.col-->
+        </div>
+        <div class="row">
+            <div class="col-xl-3 col-lg-6 text-center">
+                <div class="block block-link a b" href="">
+                    <i class="fal fa-building fa-5x c-gradient mb-4"></i>
+                    <h3 class="h4 mb-2">{{ $place.name }}</h3>
+                    <p class="text-muted mb-3">{{ $place.address }} {{ $place.postal_code }} {{ $place.city }}, {{ $place.country | upper }}</p>
+                    <a class="btn btn-purple btn-m" href="https://www.groundcontrolparis.com/" target="_blank" rel="noopener">{{ i18n "festival_content_learn_more" }}</a>
+                </div>
+            </div>
+            <div class="col-xl-3 col-lg-6 text-center">
+                <div class="block block-link a">
+                    <i class="fal fa-heart fa-5x c-gradient mb-4"></i>
+                    <h3 class="h4 mb-2">{{ i18n "festival_content_s_donate_title" | markdownify }}</h3>
+                    <p class="text-muted mb-3">{{ i18n "festival_content_s_donate_text" | markdownify }}</p>
+                    <a class="btn btn-purple btn-m" href="https://www.helloasso.com/associations/osmose-collective/collectes/paris-p2p-festival-0-bootstrap" target="_blank" rel="noopener">{{ i18n "festival_content_donate_btn" }}</a>
+                </div>
+            </div><!-- /.col -->
+            <div class="col-xl-3 col-lg-6 text-center">
+                <div class="block block-link b">
+                    <i class="fal fa-envelope-open-text fa-5x c-gradient mb-4"></i>
+                    <h3 class="h4 mb-2">{{ i18n "festival_content_news_title" | markdownify }}</h3>
+                    <p class="text-muted mb-3">{{ i18n "festival_content_news_text" | markdownify }}</p>
+                    <form class="form-newsletter" action="https://formspree.io/xzbzlaqb" method="POST">
+                        <input class="forn-control" type="text" name="_replyto" placeholder="{{ i18n `festival_content_newsletter_input` | markdownify }}">
+                        <button class="btn btn-purple btn-m" type="submit"><i class="far fa-arrow-right"></i></button>
+                    </form>
+                </div>
+            </div><!-- /.col -->
+             <div class="col-xl-3 col-lg-6 text-center">
+                <div class="block block-link">
+                    <i class="fal fa-bed fa-5x c-gradient mb-4"></i>
+                    <h3 class="h4 mb-2">{{ i18n "festival_content_hotel_title" | markdownify }}</h3>
+                    <p class="text-muted mb-3">{{ i18n "festival_content_hotel_text" | markdownify }}</p>
+                    <a class="btn btn-purple btn-m" href="https://www.zaziehotel.paris/" target="_blank" rel="noopener">{{ i18n "festival_content_learn_more" }}</a>
+                </div>
+            </div>
+        </div><!-- /.row -->
+    </div><!-- /.container -->
+</section>

--- a/themes/p2pparis/static/js/creative.js
+++ b/themes/p2pparis/static/js/creative.js
@@ -161,7 +161,42 @@ function myToggle(){
 
   }
 
+    // Only for festival page
+    if ($(".page-festival-1").length) {
 
+      // Initialize countdown clock
+      var festival_start = new Date(Date.parse(new Date('april 27, 2022 18:00:00')));
+      var festival_end = new Date(Date.parse(new Date('may 1, 2022 20:00:00')));
+      var date_now = Date.now();
+      
+      if(date_now < festival_start){
+        $('#it-soon').show();
+        initializeClock('clockdiv', festival_start);
+        $('#clockdiv').show();
+      }
+      else if(date_now < festival_end){
+        $('#it-current').show();
+        initializeClock('clockdiv', festival_end);
+        $('#clockdiv').show();
+      }
+      else {
+        $('#it-finish').show();  
+      }
+  
+      // Smooth scrolling using jQuery easing
+      $('a.js-scroll-trigger[href*="#"]:not([href="#"])').click(function() {
+        if (location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '') && location.hostname == this.hostname) {
+          var target = $(this.hash);
+          target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
+          if (target.length) {
+            $('html, body').animate({
+              scrollTop: (target.offset().top + 2)
+            }, 1000, "easeInOutExpo");
+            return true;
+          }
+        }
+      });
+    }
 
   if($(".s-filters").length) {
 


### PR DESCRIPTION
For the new festival I basically duplicated the former layout and some partials and renamed them with a `-1` suffix. This allow us to modify the theme of the new festival easily without breaking the 2020 festival page (is this something we will want to keep doing in the future ? or have more common styling and logics ?).

I also created the event on airtable and added some placeholders to test the layout (cf netlify deployment).

Tried to introduce a gray / dark theme for this festival (as discussed with @zxxma) any feedback or idea on this is welcome.